### PR TITLE
fix: make waits conform to wd api

### DIFF
--- a/lib/tests.js
+++ b/lib/tests.js
@@ -3,24 +3,30 @@ const wd = require('wd');
 const _ = require('lodash');
 const should = require('should');
 
+
 const Asserter = wd.asserters.Asserter;
 let tests = {};
 
+function markAssertionErrorForRetry (err) {
+  err.retriable = err instanceof should.AssertionError;
+  throw err;
+}
+
 function titleToMatch (match) {
-  return new Asserter(function (driver, cb) {
-    driver.title().then((title) => {
+  return new Asserter(function (driver) {
+    return driver.title().then((title) => {
       title.should.containEql(match);
-      return true;
-    }).nodeify(cb);
+      return title;
+    }).catch(markAssertionErrorForRetry);
   });
 }
 
 function contexts () {
-  return new Asserter(function (driver, cb) {
-    driver.contexts().then((contexts) => {
+  return new Asserter(function (driver) {
+    return driver.contexts().then((contexts) => {
       contexts.length.should.be.above(1);
-      return true;
-    }).nodeify(cb);
+      return contexts;
+    }).catch(markAssertionErrorForRetry);
   });
 }
 
@@ -33,8 +39,7 @@ async function selectWebview (driver) {
       return;
     }
   }
-  throw new Error("Couldn't find a webview in contexts: " +
-                  JSON.stringify(ctxs));
+  throw new Error("Couldn't find a webview in contexts: " + JSON.stringify(ctxs));
 }
 
 function isAppium1 (caps) {
@@ -242,7 +247,7 @@ tests.androidLoadTest = async function (driver, caps) {
 
   let args = await driver.elementById('textOptions');
   let goBtn = await driver.elementById('go');
- 
+
   await args.clear();
   await args.sendKeys(`-M 500 -v 20 -s ${Math.floor(iterations * intervalMs / 1000)}`);
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "request": "^2.53.0",
     "should": "^11.2.1",
     "stats-lite": "^2.0.4",
-    "wd": "^1.2.0"
+    "wd": "^1.11.4"
   },
   "scripts": {
     "test": "mocha test/"


### PR DESCRIPTION
`wd` relies on an error having a boolean `retriable` property in order to implement retries on asserters. The current implementation will try once, and if it fails it will fail altogether. This is bad on, say, slow internet connections when the page may not yet have loaded.